### PR TITLE
Dockerfile for testing Ionic and instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,19 +10,13 @@ RUN git clone https://github.com/gazebo-tooling/gzdev \
     && cd gzdev \
     && python3 gzdev.py repository enable osrf stable \
     && python3 gzdev.py repository enable osrf prerelease 
-# TODO: enable when prerelease is ready
-# RUN apt-get install -y gz-ionic \
-#     && apt-get clean \
-#     && rm -rf /var/lib/apt/lists/*
+RUN apt-get install -y gz-ionic \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 FROM ionic-prerelease AS ionic-nightly
 RUN cd gzdev \
     && python3 gzdev.py repository enable osrf nightly
-# TODO: remove when gz-ionic is in the prerelease repository
-RUN apt-get install -y gz-ionic \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-# TODO: end of block
 RUN apt-get dist-upgrade -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:noble AS ionic-prerelease
+ENV LANG C
+ENV LC_ALL C
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get install -y dirmngr git python3 python3-docopt python3-yaml python3-distro \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+RUN git clone https://github.com/gazebo-tooling/gzdev \
+    && cd gzdev \
+    && python3 gzdev.py repository enable osrf stable \
+    && python3 gzdev.py repository enable osrf prerelease 
+# TODO: enable when prerelease is ready
+# RUN apt-get install -y gz-ionic \
+#     && apt-get clean \
+#     && rm -rf /var/lib/apt/lists/*
+
+FROM ionic-prerelease AS ionic-nightly
+RUN cd gzdev \
+    && python3 gzdev.py repository enable osrf nightly
+# TODO: remove when gz-ionic is in the prerelease repository
+RUN apt-get install -y gz-ionic \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+# TODO: end of block
+RUN apt-get dist-upgrade -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# Testing platform for Gazebo Ionic
+
+Gazebo Ionic is supported for Linux only on Ubuntu Noble (24.04). For the
+testers that don't run this platform it is possible to use a virtual
+environment with GPU support to run this.
+
+## Docker ionic-prerelease image
+
+The repository contains a `Dockerfile` ready to setup an Ubuntu Noble with
+the necessary packages from the prerelease repository to run Gazebo Ionic.
+
+Build it with:
+```
+docker build --target=ionic-nightly -t ionic-prerelease - < Dockerfile
+```
+
+## Running the images with GPU support
+
+To run the ionic-prerelease image created the recommended tool is `rocker`:
+https://github.com/osrf/rocker . Follow its install instructions and for the
+nvidia users run:
+
+### Nvidia users
+
+```
+rocker --user --x11 --nvidia -- ionic-prerelease
+```
+
+### Intel users
+
+```
+rocker --user --x11 --devices /dev/dri --group-add video  -- ionic-prerelease
+```
+
+## Using the nightly packages
+
+During the testing period some hot fixes land everyday in the Gazebo
+repositories. Nightly packages are released every night into the nightly
+repository using the latest commits in the Gazebo Ionic repositories.
+
+To use the nightly image just repeat the steps before changing ionic-prerelease
+by ionic-nightly in docker build and rocker.

--- a/README.md
+++ b/README.md
@@ -17,19 +17,32 @@ docker build --target=ionic-nightly -t ionic-prerelease - < Dockerfile
 ## Running the images with GPU support
 
 To run the ionic-prerelease image created the recommended tool is `rocker`:
-https://github.com/osrf/rocker . Follow its install instructions and for the
-nvidia users run:
+https://github.com/osrf/rocker .
 
-### Nvidia users
+
+### Install rocker
+
+The `master` branch is needed to support Ubuntu Noble systems:
+```
+ python3 -m venv rocker_ws/
+ . rocker_ws/bin/activate
+ pip3 install git+https://github.com/osrf/rocker@master
+```
+
+### Launch the ionic image: Nvidia users
 
 ```
 rocker --user --x11 --nvidia -- ionic-prerelease
+# User should be now inside the Noble system with Ionic installed
+# to launch the simulator: gz sim --verbose
 ```
 
-### Intel users
+### Launch the ionic image: Intel users
 
 ```
 rocker --user --x11 --devices /dev/dri --group-add video  -- ionic-prerelease
+# User should be now inside the Noble system with Ionic installed
+# to launch the simulator: gz sim --verbose
 ```
 
 ## Using the nightly packages

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To run the ionic-prerelease image created the recommended tool is `rocker`:
 https://github.com/osrf/rocker .
 
 
-### Install rocker
+### Installing rocker
 
 The `master` branch is needed to support Ubuntu Noble systems:
 ```
@@ -29,7 +29,10 @@ The `master` branch is needed to support Ubuntu Noble systems:
  pip3 install git+https://github.com/osrf/rocker@master
 ```
 
-### Launch the ionic image: Nvidia users
+Be sure of using the same shell to launch rocker from it or run the activate
+command in the desired shell.
+
+### Launching the ionic image: Nvidia users
 
 ```
 rocker --user --x11 --nvidia -- ionic-prerelease
@@ -37,7 +40,7 @@ rocker --user --x11 --nvidia -- ionic-prerelease
 # to launch the simulator: gz sim --verbose
 ```
 
-### Launch the ionic image: Intel users
+### Launching the ionic image: Intel users
 
 ```
 rocker --user --x11 --devices /dev/dri --group-add video  -- ionic-prerelease


### PR DESCRIPTION
The PR adds a basic Dockerfile to setup the Ionic prerelease testing platform based on Ubuntu 24.04. It also add a README file with the instructions to build and run with rocker the needed environment.

### Rocker from master

**Note:** 24.04 needs rocker from master branch since there is no release supporting 24.04 as far as I can tell. To do so in a python. Instructions are in the readme.

### Intel issues

When running the tests on Ubuntu Focal using Intel i915, the gz-rendering-ogre2 log is complaining with:
```
[GUI] [Msg] Loading plugin [gz-rendering-ogre2]
libEGL warning: failed to open /dev/dri/renderD128: Permission denied
libEGL warning: failed to open /dev/dri/renderD128: Permission denied
```

There seems to be a `render` group in my base system that it is not created in the image and I'm currently unable to find which package creates it.  @iche033 confirmed that it should no be relevant to the use of the simulator.