### PR TITLE
Fix legacy format warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:noble AS ionic-prerelease
-ENV LANG C
-ENV LC_ALL C
+ENV LANG=C
+ENV LC_ALL=C
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get install -y dirmngr git python3 python3-docopt python3-yaml python3-distro \


### PR DESCRIPTION
In a build you get the following warning:
```
 2 warnings found (use docker --debug to expand):                                                                                                                                                                  
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 2)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 3)
```

This fixes the legacy format and removes the warning. 