### PR TITLE
Add the option of using docker-compose instead of rocker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ENV LANG C
 ENV LC_ALL C
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
-    && apt-get install -y dirmngr git python3 python3-docopt python3-yaml python3-distro \
+    && apt-get install -y dirmngr git python3 python3-docopt python3-yaml python3-distro sudo mesa-utils \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 RUN git clone https://github.com/gazebo-tooling/gzdev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,31 @@ RUN apt-get install -y gz-ionic \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+FROM ionic-prerelease AS ionic-prerelease-nvidia
+RUN dpkg --add-architecture i386 && \
+    apt-get update && apt-get install -y --no-install-recommends \
+        libxau6 libxau6:i386 \
+        libxdmcp6 libxdmcp6:i386 \
+        libxcb1 libxcb1:i386 \
+        libxext6 libxext6:i386 \
+        libx11-6 libx11-6:i386 \
+        libglvnd0 libglvnd0:i386 \
+        libgl1 libgl1:i386 \
+        libglx0 libglx0:i386 \
+        libegl1 libegl1:i386 \
+        libgles2 libgles2:i386 && \
+    rm -rf /var/lib/apt/lists/*
+COPY 10_nvidia.json /usr/share/glvnd/egl_vendor.d/10_nvidia.json
+# nvidia-container-runtime
+ENV NVIDIA_VISIBLE_DEVICES \
+        ${NVIDIA_VISIBLE_DEVICES:-all}
+ENV NVIDIA_DRIVER_CAPABILITIES \
+        ${NVIDIA_DRIVER_CAPABILITIES:+$NVIDIA_DRIVER_CAPABILITIES,}graphics,compat32,utility
+RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf && \
+    echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
+# Required for non-glvnd setups.
+ENV LD_LIBRARY_PATH /usr/lib/x86_64-linux-gnu:/usr/lib/i386-linux-gnu${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}:/usr/local/nvidia/lib:/usr/local/nvidia/lib64
+
 FROM ionic-prerelease AS ionic-nightly
 RUN cd gzdev \
     && python3 gzdev.py repository enable osrf nightly

--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@ Gazebo Ionic is supported for Linux only on Ubuntu Noble (24.04). For the
 testers that don't run this platform it is possible to use a virtual
 environment with GPU support to run this.
 
-## Docker ionic-prerelease image
+A couple of options to run the docker container:
+  * A: use docker and rocker
+  * B: use docker compose
+
+## Option A: using docker + rocker
+
+### Docker ionic-prerelease image
 
 The repository contains a `Dockerfile` ready to setup an Ubuntu Noble with
 the necessary packages from the prerelease repository to run Gazebo Ionic.
@@ -14,13 +20,13 @@ Build it with:
 docker build --target=ionic-nightly -t ionic-prerelease - < Dockerfile
 ```
 
-## Running the images with GPU support
+### Running the images with GPU support
 
 To run the ionic-prerelease image created the recommended tool is `rocker`:
 https://github.com/osrf/rocker .
 
 
-### Installing rocker
+#### Installing rocker
 
 The `master` branch is needed to support Ubuntu Noble systems:
 ```
@@ -32,7 +38,7 @@ The `master` branch is needed to support Ubuntu Noble systems:
 Be sure of using the same shell to launch rocker from it or run the activate
 command in the desired shell.
 
-### Launching the ionic image: Nvidia users
+#### Launching the ionic image: Nvidia users
 
 ```
 rocker --user --x11 --nvidia -- ionic-prerelease
@@ -40,7 +46,7 @@ rocker --user --x11 --nvidia -- ionic-prerelease
 # to launch the simulator: gz sim --verbose
 ```
 
-### Launching the ionic image: Intel users
+#### Launching the ionic image: Intel users
 
 ```
 rocker --user --x11 --devices /dev/dri --group-add video  -- ionic-prerelease
@@ -48,7 +54,7 @@ rocker --user --x11 --devices /dev/dri --group-add video  -- ionic-prerelease
 # to launch the simulator: gz sim --verbose
 ```
 
-## Using the nightly packages
+### Using the nightly packages
 
 During the testing period some hot fixes land everyday in the Gazebo
 repositories. Nightly packages are released every night into the nightly
@@ -56,3 +62,48 @@ repository using the latest commits in the Gazebo Ionic repositories.
 
 To use the nightly image just repeat the steps before changing ionic-prerelease
 by ionic-nightly in docker build and rocker.
+
+## Option B: using docker compose
+
+### Docker ionic-prerelease image
+
+The repository contains a `Dockerfile` ready to setup an Ubuntu Noble with
+the necessary packages from the prerelease repository to run Gazebo Ionic.
+
+Build it with:
+```
+# For intel users
+docker compose build ionic-build
+
+# For nvidia users
+docker compose build ionic-build-nvidia
+```
+### Running the images with GPU support
+
+#### Launching the ionic image: Nvidia users
+
+The [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
+installation is required to use the docker compose successfully.
+
+```
+docker compose run ionic-nvidia-run
+# User should be now inside the Noble system with Ionic installed
+# to launch the simulator: gz sim --verbose
+```
+
+#### Launching the ionic image: Intel users
+
+```
+docker compose run ionic-intel-run
+# User should be now inside the Noble system with Ionic installed
+# to launch the simulator: gz sim --verbose
+```
+
+### Using the nightly packages
+
+During the testing period some hot fixes land everyday in the Gazebo
+repositories. Nightly packages are released every night into the nightly
+repository using the latest commits in the Gazebo Ionic repositories.
+
+To use the nightly image just repeat the docker compose steps adding
+`BUILD_TYPE=nightly` before the docker compose executions.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,12 @@
 services:
   ionic-build:
-    image: ionic/prerelease
+    image: ionic/${BUILD_TYPE:-prerelease}
     build:
       context: .
       dockerfile: Dockerfile
-      target:
-        ionic-prerelease
+      target: ionic-${BUILD_TYPE:-prerelease}
   ionic-intel-run:
-    image: ionic/prerelease
+    image: ionic/${BUILD_TYPE:-prerelease}
     stdin_open: true 
     tty: true
     user: ubuntu
@@ -24,7 +23,7 @@ services:
         - /dev/log:/dev/log:ro
         - /run/log:/run/log:ro
   ionic-nvidia-run:
-    image: ionic/prerelease
+    image: ionic/${BUILD_TYPE:-prerelease}
     stdin_open: true 
     tty: true
     user: ubuntu

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,47 @@
+services:
+  ionic-build:
+    image: ionic/prerelease
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target:
+        ionic-prerelease
+  ionic-intel-run:
+    image: ionic/prerelease
+    stdin_open: true 
+    tty: true
+    user: ubuntu
+    group_add:
+      - video
+    devices:
+      - /dev/dri
+    environment:
+      - DISPLAY=unix${DISPLAY}
+      - TERM=xterm-256color
+    volumes:
+        - /sys:/sys:ro
+        - /tmp/.X11-unix:/tmp/.X11-unix:rw
+        - /dev/log:/dev/log:ro
+        - /run/log:/run/log:ro
+  ionic-nvidia-run:
+    image: ionic/prerelease
+    stdin_open: true 
+    tty: true
+    user: ubuntu
+    group_add:
+      - video
+    environment:
+      - DISPLAY=unix${DISPLAY}
+      - TERM=xterm-256color
+    volumes:
+        - /sys:/sys:ro
+        - /tmp/.X11-unix:/tmp/.X11-unix:rw
+        - /dev/log:/dev/log:ro
+        - /run/log:/run/log:ro
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,13 @@ services:
       context: .
       dockerfile: Dockerfile
       target: ionic-${BUILD_TYPE:-prerelease}
+  ionic-build-nvidia:
+    image: ionic/${BUILD_TYPE:-prerelease}-nvidia
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: ionic-${BUILD_TYPE:-prerelease}-nvidia
+
   ionic-intel-run:
     image: ionic/${BUILD_TYPE:-prerelease}
     stdin_open: true 
@@ -23,7 +30,7 @@ services:
         - /dev/log:/dev/log:ro
         - /run/log:/run/log:ro
   ionic-nvidia-run:
-    image: ionic/${BUILD_TYPE:-prerelease}
+    image: ionic/${BUILD_TYPE:-prerelease}-nvidia
     stdin_open: true 
     tty: true
     user: ubuntu


### PR DESCRIPTION
rocker is more flexible but docker-compose can work for those without a rocker installation or with other configuration needs.